### PR TITLE
VCardProperties: implement `deepCopy` methods

### DIFF
--- a/src/main/java/ezvcard/VCard.java
+++ b/src/main/java/ezvcard/VCard.java
@@ -4715,4 +4715,13 @@ public class VCard implements Iterable<VCardProperty> {
 		}
 		return altId + "";
 	}
+
+	public VCard deepCopy() {
+		VCard that = new VCard();
+		that.version = this.version;
+		for (final VCardProperty property : getProperties()) {
+			that.addProperty(property.deepCopy());
+		}
+		return that;
+	}
 }

--- a/src/main/java/ezvcard/ValidationWarnings.java
+++ b/src/main/java/ezvcard/ValidationWarnings.java
@@ -1,10 +1,7 @@
 package ezvcard;
 
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import ezvcard.property.VCardProperty;

--- a/src/main/java/ezvcard/property/Address.java
+++ b/src/main/java/ezvcard/property/Address.java
@@ -95,6 +95,19 @@ public class Address extends VCardProperty implements HasAltId {
 	private String postalCode;
 	private String country;
 
+	@Override public Address deepCopy() {
+		Address that = new Address();
+		this.copyTo(that);
+		that.poBox = this.poBox;
+		that.extendedAddress = this.extendedAddress;
+		that.streetAddress = this.streetAddress;
+		that.locality = this.locality;
+		that.region = this.region;
+		that.postalCode = this.postalCode;
+		that.country = this.country;
+		return that;
+	}
+
 	/**
 	 * Gets the P.O. (post office) box.
 	 * @return the P.O. box or null if not set

--- a/src/main/java/ezvcard/property/Agent.java
+++ b/src/main/java/ezvcard/property/Agent.java
@@ -104,6 +104,14 @@ public class Agent extends VCardProperty {
 		//empty
 	}
 
+	public Agent deepCopy() {
+		Agent that = new Agent();
+		this.copyTo(that);
+		that.url = this.url;
+		that.vcard = this.vcard;
+		return that;
+	}
+
 	/**
 	 * Creates an agent property.
 	 * @param url a URL pointing to the agent's information

--- a/src/main/java/ezvcard/property/Anniversary.java
+++ b/src/main/java/ezvcard/property/Anniversary.java
@@ -110,6 +110,12 @@ public class Anniversary extends DateOrTimeProperty {
 		super(date);
 	}
 
+	@Override public Anniversary deepCopy() {
+		Anniversary that = new Anniversary(this.getDate());
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Creates an anniversary property.
 	 * @param date the anniversary date

--- a/src/main/java/ezvcard/property/BinaryProperty.java
+++ b/src/main/java/ezvcard/property/BinaryProperty.java
@@ -62,6 +62,14 @@ public abstract class BinaryProperty<T extends MediaTypeParameter> extends VCard
 	 */
 	protected T contentType;
 
+	@Override public abstract BinaryProperty deepCopy();
+
+	protected void copyTo(BinaryProperty<T> that) {
+		that.data = this.data.clone();
+		that.url = this.url;
+		that.contentType = this.contentType;
+	}
+
 	public BinaryProperty() {
 		//empty
 	}

--- a/src/main/java/ezvcard/property/Birthday.java
+++ b/src/main/java/ezvcard/property/Birthday.java
@@ -106,6 +106,13 @@ public class Birthday extends DateOrTimeProperty {
 		super(date);
 	}
 
+	@Override
+	public Birthday deepCopy() {
+        Birthday that = new Birthday(this.getDate());
+		copyTo(that);
+		return that;
+    }
+
 	/**
 	 * Creates a birthday property.
 	 * @param date the birthday

--- a/src/main/java/ezvcard/property/Birthplace.java
+++ b/src/main/java/ezvcard/property/Birthplace.java
@@ -97,6 +97,13 @@ public class Birthplace extends PlaceProperty {
 		super();
 	}
 
+	@Override
+	public Birthplace deepCopy() {
+		Birthplace that = new Birthplace();
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Creates a new birthplace property.
 	 * @param latitude the latitude coordinate of the place

--- a/src/main/java/ezvcard/property/CalendarRequestUri.java
+++ b/src/main/java/ezvcard/property/CalendarRequestUri.java
@@ -70,6 +70,13 @@ public class CalendarRequestUri extends UriProperty implements HasAltId {
 	}
 
 	@Override
+	public CalendarRequestUri deepCopy() {
+		CalendarRequestUri that = new CalendarRequestUri(value);
+		copyTo(that);
+		return that;
+	}
+
+    @Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V4_0);
 	}

--- a/src/main/java/ezvcard/property/CalendarUri.java
+++ b/src/main/java/ezvcard/property/CalendarUri.java
@@ -69,6 +69,13 @@ public class CalendarUri extends UriProperty implements HasAltId {
 	}
 
 	@Override
+    public CalendarUri deepCopy() {
+        CalendarUri that = new CalendarUri(value);
+        copyTo(that);
+        return that;
+    }
+
+	@Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V4_0);
 	}

--- a/src/main/java/ezvcard/property/Categories.java
+++ b/src/main/java/ezvcard/property/Categories.java
@@ -64,6 +64,13 @@ import ezvcard.VCardVersion;
  */
 public class Categories extends TextListProperty implements HasAltId {
 	@Override
+	public Categories deepCopy() {
+		Categories that = new Categories();
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public List<Integer[]> getPids() {
 		return super.getPids();
 	}

--- a/src/main/java/ezvcard/property/Classification.java
+++ b/src/main/java/ezvcard/property/Classification.java
@@ -69,6 +69,13 @@ public class Classification extends TextProperty {
 	}
 
 	@Override
+    public Classification deepCopy() {
+		Classification that = new Classification(this.getValue());
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V3_0);
 	}

--- a/src/main/java/ezvcard/property/ClientPidMap.java
+++ b/src/main/java/ezvcard/property/ClientPidMap.java
@@ -104,6 +104,13 @@ public class ClientPidMap extends VCardProperty {
 		this.uri = uri;
 	}
 
+	@Override
+	public ClientPidMap deepCopy() {
+		ClientPidMap that = new ClientPidMap(pid, uri);
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Generates a CLIENTPIDMAP type that contains a random UID URI.
 	 * @param pid the PID

--- a/src/main/java/ezvcard/property/DateOrTimeProperty.java
+++ b/src/main/java/ezvcard/property/DateOrTimeProperty.java
@@ -49,6 +49,23 @@ public class DateOrTimeProperty extends VCardProperty implements HasAltId {
 	private PartialDate partialDate;
 	private boolean dateHasTime;
 
+    private DateOrTimeProperty() {}
+
+	@Override
+	public DateOrTimeProperty deepCopy() {
+		DateOrTimeProperty that = new DateOrTimeProperty();
+		copyTo(that);
+		return that;
+	}
+
+	protected void copyTo(final DateOrTimeProperty that) {
+        super.copyTo(that);
+		that.text = this.text;
+		that.date = new Date(this.date.getTime());
+		that.partialDate = this.partialDate; // immutable
+		that.dateHasTime = this.dateHasTime;
+	}
+
 	/**
 	 * Creates a date-and-or-time property.
 	 * @param date the date value

--- a/src/main/java/ezvcard/property/Deathdate.java
+++ b/src/main/java/ezvcard/property/Deathdate.java
@@ -110,6 +110,13 @@ public class Deathdate extends DateOrTimeProperty {
 		super(date);
 	}
 
+	@Override
+	public Deathdate deepCopy() {
+		Deathdate that = new Deathdate(getDate());
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Creates a deathdate property.
 	 * @param date the deathdate

--- a/src/main/java/ezvcard/property/Deathplace.java
+++ b/src/main/java/ezvcard/property/Deathplace.java
@@ -97,6 +97,13 @@ public class Deathplace extends PlaceProperty {
 		super();
 	}
 
+	@Override
+	public Deathplace deepCopy() {
+		Deathplace that = new Deathplace();
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Creates a new deathplace property.
 	 * @param latitude the latitude coordinate of the place

--- a/src/main/java/ezvcard/property/Email.java
+++ b/src/main/java/ezvcard/property/Email.java
@@ -77,6 +77,13 @@ public class Email extends TextProperty implements HasAltId {
 		super(email);
 	}
 
+	@Override
+	public Email deepCopy() {
+		Email that = new Email(getValue());
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Gets all the TYPE parameters.
 	 * @return the TYPE parameters or empty set if there are none

--- a/src/main/java/ezvcard/property/Expertise.java
+++ b/src/main/java/ezvcard/property/Expertise.java
@@ -75,6 +75,13 @@ public class Expertise extends TextProperty implements HasAltId {
 	}
 
 	@Override
+	public Expertise deepCopy() {
+		Expertise that = new Expertise(getValue());
+		copyTo(that);
+		return that;
+	}
+
+    @Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V4_0);
 	}

--- a/src/main/java/ezvcard/property/FormattedName.java
+++ b/src/main/java/ezvcard/property/FormattedName.java
@@ -64,6 +64,13 @@ public class FormattedName extends TextProperty implements HasAltId {
 		super(name);
 	}
 
+	@Override
+	public FormattedName deepCopy() {
+		FormattedName that = new FormattedName(getValue());
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Gets the TYPE parameter.
 	 * <p>

--- a/src/main/java/ezvcard/property/FreeBusyUrl.java
+++ b/src/main/java/ezvcard/property/FreeBusyUrl.java
@@ -69,6 +69,13 @@ public class FreeBusyUrl extends UriProperty implements HasAltId {
 	}
 
 	@Override
+	public FreeBusyUrl deepCopy() {
+		FreeBusyUrl that = new FreeBusyUrl(getValue());
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V4_0);
 	}

--- a/src/main/java/ezvcard/property/Gender.java
+++ b/src/main/java/ezvcard/property/Gender.java
@@ -96,6 +96,14 @@ public class Gender extends VCardProperty {
 	}
 
 	@Override
+	public Gender deepCopy() {
+		Gender that = new Gender(gender);
+		copyTo(that);
+		that.text = this.text;
+		return that;
+	}
+
+	@Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V4_0);
 	}

--- a/src/main/java/ezvcard/property/Geo.java
+++ b/src/main/java/ezvcard/property/Geo.java
@@ -97,6 +97,13 @@ public class Geo extends VCardProperty implements HasAltId {
 		this(new GeoUri.Builder(latitude, longitude).build());
 	}
 
+	@Override
+	public Geo deepCopy() {
+		Geo that = new Geo(this.uri);
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Creates a geo property.
 	 * @param uri the geo URI

--- a/src/main/java/ezvcard/property/Hobby.java
+++ b/src/main/java/ezvcard/property/Hobby.java
@@ -75,6 +75,13 @@ public class Hobby extends TextProperty implements HasAltId {
 	}
 
 	@Override
+	public Hobby deepCopy() {
+		Hobby that = new Hobby(getValue());
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V4_0);
 	}

--- a/src/main/java/ezvcard/property/ImageProperty.java
+++ b/src/main/java/ezvcard/property/ImageProperty.java
@@ -40,6 +40,16 @@ import ezvcard.parameter.ImageType;
  * @author Michael Angstadt
  */
 public class ImageProperty extends BinaryProperty<ImageType> {
+
+	protected ImageProperty() {}
+
+	@Override
+	public ImageProperty deepCopy() {
+		ImageProperty that = new ImageProperty();
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Creates an image property.
 	 * @param url the URL to the image

--- a/src/main/java/ezvcard/property/Impp.java
+++ b/src/main/java/ezvcard/property/Impp.java
@@ -84,6 +84,13 @@ public class Impp extends VCardProperty implements HasAltId {
 
 	private URI uri;
 
+	@Override
+	public Impp deepCopy() {
+		Impp that = new Impp(this.uri);
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Creates an IMPP property. Note that this class has static factory methods
 	 * for creating IMPP properties of common IM protocols.

--- a/src/main/java/ezvcard/property/Interest.java
+++ b/src/main/java/ezvcard/property/Interest.java
@@ -75,6 +75,13 @@ public class Interest extends TextProperty implements HasAltId {
 	}
 
 	@Override
+	public Interest deepCopy() {
+		Interest that = new Interest(getValue());
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V4_0);
 	}

--- a/src/main/java/ezvcard/property/Key.java
+++ b/src/main/java/ezvcard/property/Key.java
@@ -113,6 +113,14 @@ public class Key extends BinaryProperty<KeyType> {
 		super();
 	}
 
+	@Override
+	public Key deepCopy() {
+		Key that = new Key();
+		copyTo(that);
+		that.text = this.text;
+		return that;
+	}
+
 	/**
 	 * Creates a key property.
 	 * @param data the binary data

--- a/src/main/java/ezvcard/property/Kind.java
+++ b/src/main/java/ezvcard/property/Kind.java
@@ -92,6 +92,13 @@ public class Kind extends TextProperty {
 	}
 
 	@Override
+	public Kind deepCopy() {
+		Kind that = new Kind(getValue());
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V4_0);
 	}

--- a/src/main/java/ezvcard/property/Label.java
+++ b/src/main/java/ezvcard/property/Label.java
@@ -88,6 +88,14 @@ public class Label extends TextProperty {
 		super(label);
 	}
 
+
+	@Override
+	public Label deepCopy() {
+		Label that = new Label(getValue());
+		copyTo(that);
+		return that;
+	}
+
 	@Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V2_1, VCardVersion.V3_0);

--- a/src/main/java/ezvcard/property/Language.java
+++ b/src/main/java/ezvcard/property/Language.java
@@ -75,6 +75,13 @@ public class Language extends TextProperty implements HasAltId {
 	}
 
 	@Override
+	public Language deepCopy() {
+		Language that = new Language(getValue());
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V4_0);
 	}

--- a/src/main/java/ezvcard/property/ListProperty.java
+++ b/src/main/java/ezvcard/property/ListProperty.java
@@ -44,6 +44,18 @@ import ezvcard.Warning;
 public class ListProperty<T> extends VCardProperty {
 	protected List<T> values = new ArrayList<T>();
 
+	@Override
+	public ListProperty<T> deepCopy() {
+		ListProperty<T> that = new ListProperty<T>();
+		copyTo(that);
+		return that;
+	}
+
+	protected void copyTo(final ListProperty<T> that) {
+		copyTo(that);
+		that.values = new ArrayList<T>(this.values);
+	}
+
 	/**
 	 * Gest the list of values.
 	 * @return the list of values

--- a/src/main/java/ezvcard/property/Logo.java
+++ b/src/main/java/ezvcard/property/Logo.java
@@ -98,6 +98,14 @@ public class Logo extends ImageProperty {
 		super(url, type);
 	}
 
+	private Logo() {}
+
+	@Override
+	public Logo deepCopy() {
+		Logo that = new Logo();
+		copyTo(that);
+		return that;
+	}
 	/**
 	 * Creates a logo property.
 	 * @param data the binary data of the logo

--- a/src/main/java/ezvcard/property/Mailer.java
+++ b/src/main/java/ezvcard/property/Mailer.java
@@ -68,6 +68,13 @@ public class Mailer extends TextProperty {
 	}
 
 	@Override
+	public Mailer deepCopy() {
+		Mailer that = new Mailer(getValue());
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V2_1, VCardVersion.V3_0);
 	}

--- a/src/main/java/ezvcard/property/Member.java
+++ b/src/main/java/ezvcard/property/Member.java
@@ -80,6 +80,13 @@ public class Member extends UriProperty implements HasAltId {
 		super(uri);
 	}
 
+	@Override
+	public Member deepCopy() {
+		Member that = new Member(getValue());
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Creates a member property whose value is an email address.
 	 * @param email the email address

--- a/src/main/java/ezvcard/property/Nickname.java
+++ b/src/main/java/ezvcard/property/Nickname.java
@@ -68,6 +68,13 @@ public class Nickname extends TextListProperty implements HasAltId {
 		return EnumSet.of(VCardVersion.V3_0, VCardVersion.V4_0);
 	}
 
+	@Override
+	public Nickname deepCopy() {
+		Nickname that = new Nickname();
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Gets the TYPE parameter.
 	 * <p>

--- a/src/main/java/ezvcard/property/Note.java
+++ b/src/main/java/ezvcard/property/Note.java
@@ -65,6 +65,13 @@ public class Note extends TextProperty implements HasAltId {
 	}
 
 	@Override
+	public Note deepCopy() {
+		Note that = new Note(this.value);
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public List<Integer[]> getPids() {
 		return super.getPids();
 	}

--- a/src/main/java/ezvcard/property/OrgDirectory.java
+++ b/src/main/java/ezvcard/property/OrgDirectory.java
@@ -69,6 +69,13 @@ public class OrgDirectory extends UriProperty implements HasAltId {
 	}
 
 	@Override
+	public OrgDirectory deepCopy() {
+		OrgDirectory that = new OrgDirectory(getValue());
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V4_0);
 	}

--- a/src/main/java/ezvcard/property/Organization.java
+++ b/src/main/java/ezvcard/property/Organization.java
@@ -68,6 +68,13 @@ public class Organization extends TextListProperty implements HasAltId {
 	}
 
 	@Override
+	public Organization deepCopy() {
+		Organization that = new Organization();
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public void setLanguage(String language) {
 		super.setLanguage(language);
 	}

--- a/src/main/java/ezvcard/property/Photo.java
+++ b/src/main/java/ezvcard/property/Photo.java
@@ -98,6 +98,13 @@ public class Photo extends ImageProperty {
 		super(url, type);
 	}
 
+	@Override
+	public Photo deepCopy() {
+		Photo that = new Photo(getUrl(), getContentType());
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Creates a photo property.
 	 * @param data the binary data of the photo

--- a/src/main/java/ezvcard/property/PlaceProperty.java
+++ b/src/main/java/ezvcard/property/PlaceProperty.java
@@ -55,6 +55,19 @@ public class PlaceProperty extends VCardProperty implements HasAltId {
 		//empty
 	}
 
+	@Override public PlaceProperty deepCopy() {
+		PlaceProperty that = new PlaceProperty();
+		copyTo(that);
+		return that;
+	}
+
+	protected void copyTo(final PlaceProperty that) {
+		super.copyTo(that);
+		that.geoUri = this.geoUri; // immutable
+		that.uri = this.uri;
+		that.text = this.text;
+	}
+
 	/**
 	 * Creates a new place property.
 	 * @param latitude the latitude coordinate of the place

--- a/src/main/java/ezvcard/property/ProductId.java
+++ b/src/main/java/ezvcard/property/ProductId.java
@@ -68,6 +68,13 @@ public class ProductId extends TextProperty {
 	}
 
 	@Override
+	public ProductId deepCopy() {
+		ProductId that = new ProductId(getValue());
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V3_0, VCardVersion.V4_0);
 	}

--- a/src/main/java/ezvcard/property/Profile.java
+++ b/src/main/java/ezvcard/property/Profile.java
@@ -67,6 +67,13 @@ public class Profile extends TextProperty {
 	}
 
 	@Override
+	public Profile deepCopy() {
+		Profile that = new Profile();
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V3_0);
 	}

--- a/src/main/java/ezvcard/property/RawProperty.java
+++ b/src/main/java/ezvcard/property/RawProperty.java
@@ -49,6 +49,13 @@ public class RawProperty extends TextProperty {
 		this(propertyName, value, null);
 	}
 
+	@Override
+	public RawProperty deepCopy() {
+		RawProperty that = new RawProperty(this.propertyName, this.value);
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Creates a raw property.
 	 * @param propertyName the property name (e.g. "X-GENDER")

--- a/src/main/java/ezvcard/property/Related.java
+++ b/src/main/java/ezvcard/property/Related.java
@@ -89,6 +89,15 @@ public class Related extends VCardProperty implements HasAltId {
 		//empty
 	}
 
+	@Override
+	public Related deepCopy() {
+		Related that = new Related();
+		copyTo(that);
+		that.uri = this.uri;
+		that.text = this.text;
+		return that;
+	}
+
 	/**
 	 * Creates a related property.
 	 * @param uri the URI representing the person

--- a/src/main/java/ezvcard/property/Revision.java
+++ b/src/main/java/ezvcard/property/Revision.java
@@ -64,6 +64,13 @@ public class Revision extends SimpleProperty<Date> {
 		super(date);
 	}
 
+	@Override
+	public Revision deepCopy() {
+		Revision that = new Revision(new Date(getValue().getTime()));
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Creates a revision property whose value is the current time.
 	 * @return the property

--- a/src/main/java/ezvcard/property/Role.java
+++ b/src/main/java/ezvcard/property/Role.java
@@ -65,6 +65,13 @@ public class Role extends TextProperty implements HasAltId {
 	}
 
 	@Override
+	public Role deepCopy() {
+		Role that = new Role(getValue());
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public String getLanguage() {
 		return super.getLanguage();
 	}

--- a/src/main/java/ezvcard/property/SimpleProperty.java
+++ b/src/main/java/ezvcard/property/SimpleProperty.java
@@ -51,6 +51,13 @@ public class SimpleProperty<T> extends VCardProperty {
 		this.value = value;
 	}
 
+	@Override
+	public SimpleProperty<T> deepCopy() {
+		SimpleProperty<T> that = new SimpleProperty<T>(value);
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Gets the value of this property.
 	 * @return the value or null if not set

--- a/src/main/java/ezvcard/property/SortString.java
+++ b/src/main/java/ezvcard/property/SortString.java
@@ -93,6 +93,13 @@ public class SortString extends TextProperty {
 	}
 
 	@Override
+	public SortString deepCopy() {
+		SortString that = new SortString(getValue());
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V3_0);
 	}

--- a/src/main/java/ezvcard/property/Sound.java
+++ b/src/main/java/ezvcard/property/Sound.java
@@ -98,6 +98,13 @@ public class Sound extends BinaryProperty<SoundType> {
 		super(url, type);
 	}
 
+	@Override
+	public Sound deepCopy() {
+		Sound that = new Sound(getUrl(), getContentType());
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Creates a sound property.
 	 * @param data the binary data of the sound file

--- a/src/main/java/ezvcard/property/Source.java
+++ b/src/main/java/ezvcard/property/Source.java
@@ -66,6 +66,13 @@ public class Source extends UriProperty implements HasAltId {
 	}
 
 	@Override
+	public Source deepCopy() {
+		Source that = new Source(getValue());
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public List<Integer[]> getPids() {
 		return super.getPids();
 	}

--- a/src/main/java/ezvcard/property/SourceDisplayText.java
+++ b/src/main/java/ezvcard/property/SourceDisplayText.java
@@ -68,6 +68,13 @@ public class SourceDisplayText extends TextProperty {
 	}
 
 	@Override
+	public SourceDisplayText deepCopy() {
+		SourceDisplayText that = new SourceDisplayText(getValue());
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public Set<VCardVersion> _supportedVersions() {
 		return EnumSet.of(VCardVersion.V3_0);
 	}

--- a/src/main/java/ezvcard/property/StructuredName.java
+++ b/src/main/java/ezvcard/property/StructuredName.java
@@ -69,6 +69,18 @@ public class StructuredName extends VCardProperty implements HasAltId {
 	private List<String> prefixes = new ArrayList<String>();
 	private List<String> suffixes = new ArrayList<String>();
 
+	@Override
+	public StructuredName deepCopy() {
+		StructuredName that = new StructuredName();
+		copyTo(that);
+		that.family = this.family;
+		that.given = this.given;
+		that.additional = new ArrayList<String>(this.additional);
+		that.prefixes = new ArrayList<String>(this.prefixes);
+		that.suffixes = new ArrayList<String>(this.suffixes);
+		return that;
+	}
+
 	/**
 	 * Gets the family name (aka "last name").
 	 * @return the family name or null if not set

--- a/src/main/java/ezvcard/property/Telephone.java
+++ b/src/main/java/ezvcard/property/Telephone.java
@@ -77,6 +77,15 @@ public class Telephone extends VCardProperty implements HasAltId {
 	private String text;
 	private TelUri uri;
 
+	@Override
+	public Telephone deepCopy() {
+		Telephone that = new Telephone(text);
+		copyTo(that);
+		that.text = this.text;
+		that.uri = this.uri;
+		return that;
+	}
+
 	/**
 	 * Creates a telephone property.
 	 * @param text the telephone number (e.g. "(123) 555-6789")

--- a/src/main/java/ezvcard/property/TextListProperty.java
+++ b/src/main/java/ezvcard/property/TextListProperty.java
@@ -34,5 +34,11 @@ package ezvcard.property;
  * @author Michael Angstadt
  */
 public class TextListProperty extends ListProperty<String> {
-	//empty
+
+	@Override
+	public TextListProperty deepCopy() {
+		TextListProperty that = new TextListProperty();
+		copyTo(that);
+		return that;
+	}
 }

--- a/src/main/java/ezvcard/property/TextProperty.java
+++ b/src/main/java/ezvcard/property/TextProperty.java
@@ -41,4 +41,11 @@ public class TextProperty extends SimpleProperty<String> {
 	public TextProperty(String value) {
 		super(value);
 	}
+
+	@Override
+	public TextProperty deepCopy() {
+		TextProperty that = new TextProperty(getValue());
+		copyTo(that);
+		return that;
+	}
 }

--- a/src/main/java/ezvcard/property/Timezone.java
+++ b/src/main/java/ezvcard/property/Timezone.java
@@ -73,6 +73,13 @@ public class Timezone extends VCardProperty implements HasAltId {
 	private UtcOffset offset;
 	private String text;
 
+	@Override
+	public Timezone deepCopy() {
+		Timezone that = new Timezone(offset, text);
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Creates a timezone property.
 	 * @param text a free-form string representing the timezone, preferably a

--- a/src/main/java/ezvcard/property/Title.java
+++ b/src/main/java/ezvcard/property/Title.java
@@ -66,6 +66,13 @@ public class Title extends TextProperty implements HasAltId {
 	}
 
 	@Override
+	public Title deepCopy() {
+		Title that = new Title(getValue());
+		copyTo(that);
+		return that;
+	}
+
+	@Override
 	public String getLanguage() {
 		return super.getLanguage();
 	}

--- a/src/main/java/ezvcard/property/Uid.java
+++ b/src/main/java/ezvcard/property/Uid.java
@@ -68,6 +68,13 @@ public class Uid extends UriProperty {
 		super(uid);
 	}
 
+	@Override
+	public Uid deepCopy() {
+		Uid that = new Uid(getValue());
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Creates a UID property that contains a random UUID URI.
 	 * @return the property

--- a/src/main/java/ezvcard/property/UriProperty.java
+++ b/src/main/java/ezvcard/property/UriProperty.java
@@ -41,4 +41,11 @@ public class UriProperty extends TextProperty {
 	public UriProperty(String uri) {
 		super(uri);
 	}
+
+	@Override
+	public UriProperty deepCopy() {
+		UriProperty that = new UriProperty(getValue());
+		copyTo(that);
+		return that;
+	}
 }

--- a/src/main/java/ezvcard/property/Url.java
+++ b/src/main/java/ezvcard/property/Url.java
@@ -64,6 +64,13 @@ public class Url extends UriProperty implements HasAltId {
 		super(url);
 	}
 
+	@Override
+	public Url deepCopy() {
+		Url that = new Url(getValue());
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Gets the MEDIATYPE parameter.
 	 * <p>

--- a/src/main/java/ezvcard/property/VCardProperty.java
+++ b/src/main/java/ezvcard/property/VCardProperty.java
@@ -10,6 +10,7 @@ import ezvcard.VCard;
 import ezvcard.VCardVersion;
 import ezvcard.Warning;
 import ezvcard.parameter.VCardParameters;
+import lombok.*;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -335,5 +336,20 @@ public abstract class VCardProperty implements Comparable<VCardProperty> {
 	 */
 	void setIndex(Integer index) {
 		parameters.setIndex(index);
+	}
+
+	/**
+	 * Returns a deep copy of this property such that
+	 * <code>that.deepCopy().equals(that)</code>, and modifications made
+	 * to the copy are not shared by the copied instance.
+	 */
+	public abstract VCardProperty deepCopy();
+
+	/**
+	 * helper method for implementors of deepCopy().
+	 */
+	protected void copyTo(VCardProperty that) {
+		that.group = this.group;
+		that.parameters = new VCardParameters(this.parameters);
 	}
 }

--- a/src/main/java/ezvcard/property/Xml.java
+++ b/src/main/java/ezvcard/property/Xml.java
@@ -75,6 +75,13 @@ public class Xml extends SimpleProperty<Document> implements HasAltId {
 		this(XmlUtils.toDocument(xml));
 	}
 
+	@Override
+	public Xml deepCopy() {
+		Xml that = new Xml(getValue());
+		copyTo(that);
+		return that;
+	}
+
 	/**
 	 * Creates an XML property.
 	 * @param element the XML element to use as the property's value (the

--- a/src/test/java/ezvcard/VCardTest.java
+++ b/src/test/java/ezvcard/VCardTest.java
@@ -242,6 +242,13 @@ public class VCardTest {
 		public void setAltId(String altId) {
 			this.altId = altId;
 		}
+
+		@Override
+		public VCardProperty deepCopy() {
+			HasAltIdImpl that = new HasAltIdImpl(altId);
+			copyTo(that);
+			return that;
+		}
 	}
 
 	private class VCardPropertyImpl extends VCardProperty {
@@ -253,6 +260,15 @@ public class VCardTest {
 			validateVersion = version;
 			validateVCard = vcard;
 			warnings.add(new Warning(0));
+		}
+
+		@Override
+		public VCardProperty deepCopy() {
+			VCardPropertyImpl that = new VCardPropertyImpl();
+			copyTo(that);
+			that.validateVersion = this.validateVersion;
+			that.validateVCard = this.validateVCard.deepCopy();
+			return that;
 		}
 	}
 }

--- a/src/test/java/ezvcard/ValidationWarningsTest.java
+++ b/src/test/java/ezvcard/ValidationWarningsTest.java
@@ -90,14 +90,23 @@ public class ValidationWarningsTest {
 	}
 
 	private class TestProperty1 extends VCardProperty {
-		//empty
+		@Override
+		public VCardProperty deepCopy() {
+			return new TestProperty1();
+		}
 	}
 
 	private class TestProperty2 extends VCardProperty {
-		//empty
+		@Override
+		public VCardProperty deepCopy() {
+			return new TestProperty1();
+		}
 	}
 
 	private class TestProperty3 extends VCardProperty {
-		//empty
+		@Override
+		public VCardProperty deepCopy() {
+			return new TestProperty1();
+		}
 	}
 }

--- a/src/test/java/ezvcard/io/AgeType.java
+++ b/src/test/java/ezvcard/io/AgeType.java
@@ -49,6 +49,11 @@ public class AgeType extends VCardProperty {
 		this.age = age;
 	}
 
+	@Override
+	public VCardProperty deepCopy() {
+		return new AgeType(age);
+	}
+
 	public static class AgeScribe extends VCardPropertyScribe<AgeType> {
 		public AgeScribe() {
 			super(AgeType.class, "X-AGE");

--- a/src/test/java/ezvcard/io/LuckyNumType.java
+++ b/src/test/java/ezvcard/io/LuckyNumType.java
@@ -56,6 +56,13 @@ public class LuckyNumType extends VCardProperty {
 		this.luckyNum = luckyNum;
 	}
 
+	@Override
+	public VCardProperty deepCopy() {
+		LuckyNumType that = new LuckyNumType(luckyNum);
+		copyTo(that);
+		return that;
+	}
+
 	public static class LuckyNumScribe extends VCardPropertyScribe<LuckyNumType> {
 		public LuckyNumScribe() {
 			super(LuckyNumType.class, "X-LUCKY-NUM", new QName("http://luckynum.com", "lucky-num"));

--- a/src/test/java/ezvcard/io/MyFormattedNameType.java
+++ b/src/test/java/ezvcard/io/MyFormattedNameType.java
@@ -50,6 +50,13 @@ public class MyFormattedNameType extends VCardProperty {
 		this.value = value;
 	}
 
+	@Override
+	public MyFormattedNameType deepCopy() {
+		MyFormattedNameType that = new MyFormattedNameType(value);
+		copyTo(that);
+		return that;
+	}
+
 	public static class MyFormattedNameScribe extends VCardPropertyScribe<MyFormattedNameType> {
 		public MyFormattedNameScribe() {
 			super(MyFormattedNameType.class, "FN");

--- a/src/test/java/ezvcard/io/SalaryType.java
+++ b/src/test/java/ezvcard/io/SalaryType.java
@@ -50,6 +50,11 @@ public class SalaryType extends VCardProperty {
 		this.salary = salary;
 	}
 
+	@Override
+	public VCardProperty deepCopy() {
+		return new SalaryType(salary);
+	}
+
 	public static class SalaryScribe extends VCardPropertyScribe<SalaryType> {
 		public SalaryScribe() {
 			super(SalaryType.class, "X-SALARY");

--- a/src/test/java/ezvcard/io/StreamWriterTest.java
+++ b/src/test/java/ezvcard/io/StreamWriterTest.java
@@ -310,6 +310,9 @@ public class StreamWriterTest {
 	}
 
 	private class TestProperty extends VCardProperty {
-		//empty
+		@Override
+		public VCardProperty deepCopy() {
+			return this;
+		}
 	}
 }

--- a/src/test/java/ezvcard/io/json/JCardReaderTest.java
+++ b/src/test/java/ezvcard/io/json/JCardReaderTest.java
@@ -427,6 +427,11 @@ public class JCardReaderTest {
 		public TypeForTesting(JCardValue value) {
 			this.value = value;
 		}
+
+		@Override
+		public VCardProperty deepCopy() {
+			return new TypeForTesting(value);
+		}
 	}
 
 	private static class TypeForTestingScribe extends VCardPropertyScribe<TypeForTesting> {

--- a/src/test/java/ezvcard/io/json/JCardWriterTest.java
+++ b/src/test/java/ezvcard/io/json/JCardWriterTest.java
@@ -383,6 +383,11 @@ public class JCardWriterTest {
 		public TestProperty(JCardValue value) {
 			this.value = value;
 		}
+
+		@Override
+		public VCardProperty deepCopy() {
+			return new TestProperty(value);
+		}
 	}
 
 	private static class TestScribe extends VCardPropertyScribe<TestProperty> {

--- a/src/test/java/ezvcard/io/scribe/BinaryPropertyScribeTest.java
+++ b/src/test/java/ezvcard/io/scribe/BinaryPropertyScribeTest.java
@@ -328,6 +328,11 @@ public class BinaryPropertyScribeTest {
 	}
 
 	private static class BinaryTypeImpl extends BinaryProperty<ImageType> {
+		@Override
+		public BinaryProperty deepCopy() {
+			return new BinaryTypeImpl();
+		}
+
 		public BinaryTypeImpl() {
 			super((String) null, null);
 		}

--- a/src/test/java/ezvcard/io/scribe/SimplePropertyScribeTest.java
+++ b/src/test/java/ezvcard/io/scribe/SimplePropertyScribeTest.java
@@ -115,6 +115,11 @@ public class SimplePropertyScribeTest {
 		public TestProperty(String value) {
 			this.value = value;
 		}
+
+		@Override
+		public VCardProperty deepCopy() {
+			return new TestProperty(value);
+		}
 	}
 
 	private Check<TestProperty> hasText(final String text) {

--- a/src/test/java/ezvcard/io/scribe/VCardPropertyScribeTest.java
+++ b/src/test/java/ezvcard/io/scribe/VCardPropertyScribeTest.java
@@ -516,5 +516,10 @@ public class VCardPropertyScribeTest {
 			this.value = value;
 			this.parsedDataType = parsedDataType;
 		}
+
+		@Override
+		public VCardProperty deepCopy() {
+			return new TestProperty(value, parsedDataType);
+		}
 	}
 }

--- a/src/test/java/ezvcard/io/text/VCardReaderTest.java
+++ b/src/test/java/ezvcard/io/text/VCardReaderTest.java
@@ -539,6 +539,14 @@ public class VCardReaderTest {
 
 	private static class Nested extends VCardProperty {
 		private VCard vcard = new VCard(); //init this to a new VCard instance to test for the fact that this should be set to null
+
+		@Override
+		public VCardProperty deepCopy() {
+			Nested that = new Nested();
+			copyTo(that);
+			that.vcard = vcard.deepCopy();
+			return that;
+		}
 	}
 
 	private static class NestedScribe extends VCardPropertyScribe<Nested> {
@@ -837,7 +845,10 @@ public class VCardReaderTest {
 	}
 
 	private static class WarningsProperty extends VCardProperty {
-		//empty
+		@Override
+		public VCardProperty deepCopy() {
+			return new WarningsProperty();
+		}
 	}
 
 	private static class WarningsScribe extends VCardPropertyScribe<WarningsProperty> {
@@ -983,6 +994,11 @@ public class VCardReaderTest {
 
 		public ValueProp(VCardDataType dataType) {
 			this.dataType = dataType;
+		}
+
+		@Override
+		public VCardProperty deepCopy() {
+			return new ValueProp(dataType);
 		}
 	}
 

--- a/src/test/java/ezvcard/io/text/VCardWriterTest.java
+++ b/src/test/java/ezvcard/io/text/VCardWriterTest.java
@@ -367,16 +367,28 @@ public class VCardWriterTest {
 		}
 
 		class DateProperty extends VCardProperty {
-			//empty
+			@Override
+			public VCardProperty deepCopy() {
+				return this;
+			}
 		}
 		class DateTimeProperty extends VCardProperty {
-			//empty
+			@Override
+			public VCardProperty deepCopy() {
+				return this;
+			}
 		}
 		class TimeProperty extends VCardProperty {
-			//empty
+			@Override
+			public VCardProperty deepCopy() {
+				return this;
+			}
 		}
 		class DateAndOrTimeProperty extends VCardProperty {
-			//empty
+			@Override
+			public VCardProperty deepCopy() {
+				return this;
+			}
 		}
 
 		VCard vcard = new VCard();

--- a/src/test/java/ezvcard/io/xml/XCardDocumentTest.java
+++ b/src/test/java/ezvcard/io/xml/XCardDocumentTest.java
@@ -895,7 +895,10 @@ public class XCardDocumentTest {
 	}
 
 	private static class EmbeddedProperty extends VCardProperty {
-		//empty
+		@Override
+		public VCardProperty deepCopy() {
+			return new EmbeddedProperty();
+		}
 	}
 
 	private static class EmbeddedScribe extends VCardPropertyScribe<EmbeddedProperty> {

--- a/src/test/java/ezvcard/io/xml/XCardWriterTest.java
+++ b/src/test/java/ezvcard/io/xml/XCardWriterTest.java
@@ -741,7 +741,10 @@ public class XCardWriterTest {
 	}
 
 	private static class EmbeddedProperty extends VCardProperty {
-		//empty
+		@Override
+		public VCardProperty deepCopy() {
+			return this;
+		}
 	}
 
 	private static class EmbeddedScribe extends VCardPropertyScribe<EmbeddedProperty> {

--- a/src/test/java/ezvcard/property/BinaryPropertyTest.java
+++ b/src/test/java/ezvcard/property/BinaryPropertyTest.java
@@ -54,6 +54,11 @@ public class BinaryPropertyTest {
 	}
 
 	private class BinaryTypeImpl extends BinaryProperty<ImageType> {
+		@Override
+		public BinaryProperty deepCopy() {
+			return new BinaryTypeImpl();
+		}
+
 		public BinaryTypeImpl() {
 			super((String) null, null);
 		}

--- a/src/test/java/ezvcard/property/CannotParseProperty.java
+++ b/src/test/java/ezvcard/property/CannotParseProperty.java
@@ -1,5 +1,8 @@
 package ezvcard.property;
 
 public class CannotParseProperty extends VCardProperty {
-	//empty
+	@Override
+	public VCardProperty deepCopy() {
+		return new CannotParseProperty();
+	}
 }

--- a/src/test/java/ezvcard/property/FavoriteColors.java
+++ b/src/test/java/ezvcard/property/FavoriteColors.java
@@ -75,6 +75,14 @@ public class FavoriteColors extends VCardProperty {
 		}
 	}
 
+	@Override
+	public VCardProperty deepCopy() {
+		FavoriteColors that = new FavoriteColors();
+		copyTo(that);
+		that.colors = new ArrayList<String>(this.colors);
+		return that;
+	}
+
 	public static class FavoriteColorsScribe extends VCardPropertyScribe<FavoriteColors> {
 		public FavoriteColorsScribe() {
 			super(FavoriteColors.class, "X-FAV-COLORS");

--- a/src/test/java/ezvcard/property/SkipMeProperty.java
+++ b/src/test/java/ezvcard/property/SkipMeProperty.java
@@ -32,5 +32,8 @@ import ezvcard.io.scribe.SkipMeScribe;
  * @author Michael Angstadt
  */
 public class SkipMeProperty extends VCardProperty {
-	//empty
+	@Override
+	public VCardProperty deepCopy() {
+		return this;
+	}
 }

--- a/src/test/java/ezvcard/property/VCardPropertyTest.java
+++ b/src/test/java/ezvcard/property/VCardPropertyTest.java
@@ -96,7 +96,10 @@ public class VCardPropertyTest {
 	}
 
 	private class VCardTypeImpl extends VCardProperty {
-		//empty
+		@Override
+		public VCardTypeImpl deepCopy() {
+			return new VCardTypeImpl();
+		}
 	}
 
 	private class ValidateType extends VCardProperty {
@@ -110,6 +113,13 @@ public class VCardPropertyTest {
 		@Override
 		public void _validate(List<Warning> warnings, VCardVersion version, VCard vcard) {
 			validateCalled = true;
+		}
+
+		@Override
+		public ValidateType deepCopy() {
+			ValidateType that = new ValidateType();
+			copyTo(that);
+			return that;
 		}
 	}
 }


### PR DESCRIPTION
I dunno about this actually, the `copyTo` helpers are awkward with the abstract classes and all. It sure is annoying not being able to copy VCards without a roundtrip through String though.
