### PR TITLE
VCard: Don't copy list on `getProperties(Class)`.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>com.googlecode.ez-vcard</groupId>
 	<artifactId>ez-vcard</artifactId>
 	<packaging>bundle</packaging> <!-- "bundle" used for OSGi support -->
-	<version>0.9.15-fc</version>
+	<version>0.9.16-fc</version>
 	<name>ez-vcard</name>
 	<url>http://github.com/fullcontact/ez-vcard</url>
 	<inceptionYear>2012</inceptionYear>

--- a/src/main/java/ezvcard/VCard.java
+++ b/src/main/java/ezvcard/VCard.java
@@ -4366,15 +4366,10 @@ public class VCard implements Iterable<VCardProperty> {
 	 * @param clazz the property class
 	 * @return the properties
 	 */
+	@SuppressWarnings({"rawtypes","unchecked"})
 	public <T extends VCardProperty> List<T> getProperties(Class<T> clazz) {
 		List<VCardProperty> properties = this.properties.get(clazz);
-
-		//cast to the requested class
-		List<T> listToReturn = new ArrayList<T>(properties.size());
-		for (VCardProperty property : properties) {
-			listToReturn.add(clazz.cast(property));
-		}
-		return listToReturn;
+		return (List<T>)(List)properties;
 	}
 
 	/**


### PR DESCRIPTION
This is what I actually intended to do before deciding I should tackle
https://github.com/fullcontact/ez-vcard/pull/5 first. (Note that this does
not build off of that; this is simply from current master.)

Basically, instead of creating a brand new `List` to hold the results
from `getProperties(Class)`, we instead simply return the `List` the
`ListMultimap` gives us, cast to the appropriate type.

This is both better for performance, and means one can do destructive
filtering of properties of a particular class by using
`Iterator.remove()`. Previously, we would accumulate the properties we
wanted to remove into a new `List`, then use `removeProperty` to remove
each of them, which is O(n²) (significant when _n_ = 3500) and a lot
harder to read overall.

@blendmaster 
